### PR TITLE
support downloading to a writer

### DIFF
--- a/zones.go
+++ b/zones.go
@@ -22,7 +22,7 @@ type DownloadInfo struct {
 func (c *Client) DownloadZoneToWriter(url string, dest io.Writer) (int64, error) {
 	resp, err := c.apiRequest(true, "GET", url, nil)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Support downloading a zone file to an io.Writer allows code reuse and the hidden effects of calling os.Create within a function.