### PR TITLE
add '-exclude' list to exclude specific zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Implements a client for the officially documented [CZDS REST API](https://github
 
 ```console
 Usage of czds-dl:
+  -exclude string
+        don't fetch these zones
   -force
         force redownloading the zone even if it already exists on local disk with same size and modification date
   -out string


### PR DESCRIPTION
When running 'redownload', a user may wish to exclude some zones. To do this, you can now specify the '-exclude' option.  This option takes as arguments a list of comma-separated zone names to avoid downloading.

'-exclude' cannot be specified together with '-zone'

Example:

czds-dl [...] -exclude com,net,biz